### PR TITLE
Wrapped animate with this functionality

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013 Alex Zaslavsky
+Copyright (c) 2014 Alex Zaslavsky
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2013 Alex Zaslavsky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README
+++ b/README
@@ -1,6 +1,6 @@
-jQuery Animate Auto Values Plugin v.1.0
+jQuery animateAuto Plugin
+
+This plugin is developed from the original source provided by at the following URL:
 http://darcyclarke.me/development/fix-jquerys-animate-to-allow-auto-values/
 
-Copyright 2011, Darcy Clarke
-Do what you want license
-
+Licensed using the MIT License.

--- a/README
+++ b/README
@@ -1,6 +1,0 @@
-jQuery animateAuto Plugin
-
-This plugin is developed from the original source provided by at the following URL:
-http://darcyclarke.me/development/fix-jquerys-animate-to-allow-auto-values/
-
-Licensed using the MIT License.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ A very simply plugin that extends the native jQuery.fn.animate function to suppo
 	testDiv.animate({
 		height: 'auto',
 		width: 'auto',
-		color: 'red'
 	}, 500, 'linear', function() {
 		console.log('Oh look, the animation finished, and now we're getting this fancy callback.');
 	})

--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ License
 ------------
 MIT License, Copyright 2013, Alex Zaslavsky
 
-This plugin is developed from the original source provided by at the following URL:
+This plugin is developed from the original source provided at the following URL:
 http://darcyclarke.me/development/fix-jquerys-animate-to-allow-auto-values/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-jQuery animateAuto Plugin v1.1.2
+jQuery animateAuto Plugin v1.1.3
 =============
 
 A very simply plugin that extends the native jQuery.fn.animate function to support 'auto' as a viable property for width or height animations.  So, whereas the following example would previously throw all sorts of errors (or simply not work), it is now a perfectly valid animation hash:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+jQuery animateAuto Plugin v1.1
+=============
+
+A very simply plugin that extends the native jQuery.fn.animate function to support 'auto' as a viable property for width or height animations.  So, whereas the following example would previously throw all sorts of errors (or simply not work), it is now a perfectly valid animation hash:
+
+	//First load jQuery (obviously), then run the plugin code sometime before you animate stuff
+	var testDiv = $('<div style="height: 20px, width: 30px;"/>').appendTo('body');
+
+	//Animate to whatever testDiv's auto height and width would be
+	testDiv.animate({
+		height: 'auto',
+		width: 'auto',
+		color: 'red'
+	}, 500, 'linear', function() {
+		console.log('Oh look, the animation finished, and now we're getting this fancy callback.');
+	})
+
+License
+------------
+MIT License, Copyright 2013, Alex Zaslavsky
+
+This plugin is developed from the original source provided by at the following URL:
+http://darcyclarke.me/development/fix-jquerys-animate-to-allow-auto-values/

--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ License
 ------------
 MIT License, Copyright 2013, Alex Zaslavsky
 
-This plugin is developed from the original source provided at the following URL:
+This plugin is developed from the original source provided by Darcy Clarke at the following URL:
 http://darcyclarke.me/development/fix-jquerys-animate-to-allow-auto-values/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-jQuery animateAuto Plugin v1.1.3
+jQuery animateAuto Plugin v1.1.4
 =============
 
 A very simply plugin that extends the native jQuery.fn.animate function to support 'auto' as a viable property for width or height animations.  So, whereas the following example would previously throw all sorts of errors (or simply not work), it is now a perfectly valid animation hash:
@@ -16,7 +16,7 @@ A very simply plugin that extends the native jQuery.fn.animate function to suppo
 
 License
 ------------
-MIT License, Copyright 2013, Alex Zaslavsky
+MIT License, Copyright 2014, Alex Zaslavsky
 
 This plugin is developed from the original source provided by Darcy Clarke at the following URL:
 http://darcyclarke.me/development/fix-jquerys-animate-to-allow-auto-values/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-jQuery animateAuto Plugin v1.1
+jQuery animateAuto Plugin v1.1.2
 =============
 
 A very simply plugin that extends the native jQuery.fn.animate function to support 'auto' as a viable property for width or height animations.  So, whereas the following example would previously throw all sorts of errors (or simply not work), it is now a perfectly valid animation hash:

--- a/animate_auto.jquery.js
+++ b/animate_auto.jquery.js
@@ -1,6 +1,6 @@
 /*!
 *
-* jQuery animateAuto Plugin v.1.0
+* jQuery animateAuto Plugin 1.1.2
 * Based on the original code provided by Darcy Clarke at:
 * http://darcyclarke.me/development/fix-jquerys-animate-to-allow-auto-values/
 *
@@ -18,7 +18,7 @@
 		var props = arguments[0];
 		var opts = jQuery.speed(arguments[1], arguments[2], arguments[3]);
 
-		var elem, clone, height, width;
+		var elem, clone, height, width, changed, options, callback;
 		return this.each(function(i, el){
 			//Create a copy of the element, then measure it's height and width if they were "auto"
 			elem = $(el);
@@ -28,7 +28,7 @@
 			clone.remove();
 
 			//Temporarily change the height and width property if the original parameters had them listed as "auto"
-			var changed = {};
+			changed = {};
 			if (props.height && props.height === 'auto') {
 				changed.height = props.height = height;
 			}
@@ -37,20 +37,20 @@
 			}
 
 			//Wrap the callback in function that ensures the height/width is reset to "auto" after the animation is over
-			var wrappedCallback = function() {
-				//Reset the height/width css properties to "auto"
-				for (var x in changed) {
-					elem.css(x, 'auto');
-				}
-
-				//If there is are callback functions, fire them
-				if (opts.callback) {
-					opts.callback.call(elem);
-				}
-			};
+			options = $.extend(true, {}, opts);
+			if (options.callback) {
+				callback = options.callback;
+				options.callback = function() {
+					//Reset the height/width css properties to "auto"
+					for (var x in changed) {
+						elem.css(x, 'auto');
+					}
+					callback.call(elem);
+				};
+			}
 
 			//Do the animation
 			animate.call(elem, props, opts);
-		});
+		});  
 	}
 }(jQuery));

--- a/animate_auto.jquery.js
+++ b/animate_auto.jquery.js
@@ -9,45 +9,48 @@
 * 
 */
 
-var animate = jQuery.fn.animate;
+(function (jQuery) {
+	var $ = jQuery;
+	var animate = jQuery.fn.animate;
 
-jQuery.fn.animate = function(){
-	//Extract the animation properties from the arguments list, and use jQuery.speed to identify the remaining parameters
-	var props = arguments[0];
-	var opts = jQuery.speed(arguments[1], arguments[2], arguments[3]);
+	jQuery.fn.animate = function(){
+		//Extract the animation properties from the arguments list, and use jQuery.speed to identify the remaining parameters
+		var props = arguments[0];
+		var opts = jQuery.speed(arguments[1], arguments[2], arguments[3]);
 
-	var elem, clone, height, width;
-	return this.each(function(i, el){
-		//Create a copy of the element, then measure it's height and width if they were "auto"
-		elem = $(el);
-		clone = elem.clone().css({"height":"auto","width":"auto"}).appendTo(elem.parent());
-		height = clone.css("height");
-		width = clone.css("width");
-		clone.remove();
+		var elem, clone, height, width;
+		return this.each(function(i, el){
+			//Create a copy of the element, then measure it's height and width if they were "auto"
+			elem = $(el);
+			clone = elem.clone().css({"height":"auto","width":"auto"}).appendTo(elem.parent());
+			height = clone.css("height");
+			width = clone.css("width");
+			clone.remove();
 
-		//Temporarily change the height and width property if the original parameters had them listed as "auto"
-		var changed = {};
-		if (props.height && props.height === 'auto') {
-			changed.height = props.height = height;
-		}
-		if (props.width && props.width === 'auto') {
-			changed.width = props.width = width;
-		}
-
-		//Wrap the callback in function that ensures the height/width is reset to "auto" after the animation is over
-		var wrappedCallback = function() {
-			//Reset the height/width css properties to "auto"
-			for (var x in changed) {
-				elem.css(x, 'auto');
+			//Temporarily change the height and width property if the original parameters had them listed as "auto"
+			var changed = {};
+			if (props.height && props.height === 'auto') {
+				changed.height = props.height = height;
+			}
+			if (props.width && props.width === 'auto') {
+				changed.width = props.width = width;
 			}
 
-			//If there is are callback functions, fire them
-			if (opts.callback) {
-				opts.callback.call(elem);
-			}
-		};
+			//Wrap the callback in function that ensures the height/width is reset to "auto" after the animation is over
+			var wrappedCallback = function() {
+				//Reset the height/width css properties to "auto"
+				for (var x in changed) {
+					elem.css(x, 'auto');
+				}
 
-		//Do the animation
-		animate.call(elem, props, opts);
-	});
-}
+				//If there is are callback functions, fire them
+				if (opts.callback) {
+					opts.callback.call(elem);
+				}
+			};
+
+			//Do the animation
+			animate.call(elem, props, opts);
+		});
+	}
+}(jQuery));

--- a/animate_auto.jquery.js
+++ b/animate_auto.jquery.js
@@ -9,38 +9,45 @@
 * 
 */
 
-jQuery.fn.animateAuto = function(props, speed, callback){
-	var elem, height, width;
+var animate = jQuery.fn.animate;
+
+jQuery.fn.animate = function(){
+	//Extract the animation properties from the arguments list, and use jQuery.speed to identify the remaining parameters
+	var props = arguments[0];
+	var opts = jQuery.speed(arguments[1], arguments[2], arguments[3]);
+
+	var elem, clone, height, width;
 	return this.each(function(i, el){
 		//Create a copy of the element, then measure it's height and width if they were "auto"
-		el = $(el);
-		elem = el.clone().css({"height":"auto","width":"auto"}).appendTo(el.parent());
-		height = elem.css("height");
-		width = elem.css("width");
-		elem.remove();
+		elem = $(el);
+		clone = elem.clone().css({"height":"auto","width":"auto"}).appendTo(elem.parent());
+		height = clone.css("height");
+		width = clone.css("width");
+		clone.remove();
 
-		//Wrape the callback in function that ensures the height/width is reset to "auto" after the animation is over
+		//Temporarily change the height and width property if the original parameters had them listed as "auto"
+		var changed = {};
+		if (props.height && props.height === 'auto') {
+			changed.height = props.height = height;
+		}
+		if (props.width && props.width === 'auto') {
+			changed.width = props.width = width;
+		}
+
+		//Wrap the callback in function that ensures the height/width is reset to "auto" after the animation is over
 		var wrappedCallback = function() {
-			//Reset the height/width css property to auto
-			if (prop !== 'both') {
-				el.css(prop, 'auto');
-			} else {
-				el.css({height: 'auto', width: 'auto' });
+			//Reset the height/width css properties to "auto"
+			for (var x in changed) {
+				elem.css(x, 'auto');
 			}
 
-			//If there is a passed callback function, fire it
-			if (callback) {
-				callback.call(el);
+			//If there is are callback functions, fire them
+			if (opts.callback) {
+				opts.callback.call(elem);
 			}
 		};
 
 		//Do the animation
-		if (props.height && props.height === 'auto') {
-			props.height = height;
-		}
-		if (props.width && props.width === 'auto') {
-			props.width = width;
-		}
-		el.animate(props, speed, wrappedCallback);
+		animate.call(elem, props, opts);
 	});
 }

--- a/animate_auto.jquery.js
+++ b/animate_auto.jquery.js
@@ -9,19 +9,38 @@
 * 
 */
 
-jQuery.fn.animateAuto = function(prop, speed, callback){
-    var elem, height, width;
-    return this.each(function(i, el){
-        el = jQuery(el), elem = el.clone().css({"height":"auto","width":"auto"}).appendTo("body");
-        height = elem.css("height"),
-        width = elem.css("width"),
-        elem.remove();
+jQuery.fn.animateAuto = function(props, speed, callback){
+	var elem, height, width;
+	return this.each(function(i, el){
+		//Create a copy of the element, then measure it's height and width if they were "auto"
+		el = $(el);
+		elem = el.clone().css({"height":"auto","width":"auto"}).appendTo(el.parent());
+		height = elem.css("height");
+		width = elem.css("width");
+		elem.remove();
 
-        if(prop === "height")
-         el.animate({"height":height}, speed, callback);
-        else if(prop === "width")
-          el.animate({"width":width}, speed, callback);  
-        else if(prop === "both")
-          el.animate({"width":width,"height":height}, speed, callback);
-    });  
+		//Wrape the callback in function that ensures the height/width is reset to "auto" after the animation is over
+		var wrappedCallback = function() {
+			//Reset the height/width css property to auto
+			if (prop !== 'both') {
+				el.css(prop, 'auto');
+			} else {
+				el.css({height: 'auto', width: 'auto' });
+			}
+
+			//If there is a passed callback function, fire it
+			if (callback) {
+				callback.call(el);
+			}
+		};
+
+		//Do the animation
+		if (props.height && props.height === 'auto') {
+			props.height = height;
+		}
+		if (props.width && props.width === 'auto') {
+			props.width = width;
+		}
+		el.animate(props, speed, wrappedCallback);
+	});
 }

--- a/animate_auto.jquery.js
+++ b/animate_auto.jquery.js
@@ -1,10 +1,10 @@
 /*!
 *
-* jQuery animateAuto Plugin v1.1.3
+* jQuery animateAuto Plugin v1.1.4
 * Based on the original code provided by Darcy Clarke at:
 * http://darcyclarke.me/development/fix-jquerys-animate-to-allow-auto-values/
 *
-* Copyright 2013, Alex Zaslavsky
+* Copyright 2014, Alex Zaslavsky
 * MIT License
 * 
 */
@@ -12,14 +12,15 @@
 (function (jQuery) {
 	var $ = jQuery;
 	var animate = jQuery.fn.animate;
-
+	
 	jQuery.fn.animate = function(){
 		//Extract the animation properties from the arguments list, and use jQuery.speed to identify the remaining parameters
 		var props = arguments[0];
 		var opts = jQuery.speed(arguments[1], arguments[2], arguments[3]);
+		//opts.queue = false;
 
-		var elem, clone, height, width, changed, options, callback;
 		return this.each(function(i, el){
+			var elem, clone, height, width, changed, options, callback;
 			//Create a copy of the element, then measure it's height and width if they were "auto"
 			elem = $(el);
 			clone = elem.clone().css({height:'auto', width:'auto'}).appendTo(elem.parent());
@@ -38,9 +39,9 @@
 
 			//Wrap the callback in function that ensures the height/width is reset to "auto" after the animation is over
 			options = $.extend(true, {}, opts);
-			if (options.callback) {
-				callback = options.callback;
-				options.callback = function() {
+			if (options.complete) {
+				callback = options.complete;
+				options.complete = function() {
 					//Reset the height/width css properties to "auto"
 					for (var x in changed) {
 						elem.css(x, 'auto');
@@ -50,7 +51,7 @@
 			}
 
 			//Do the animation
-			animate.call(elem, props, opts);
+			animate.call(elem, props, options);
 		});  
 	}
 }(jQuery));

--- a/animate_auto.jquery.js
+++ b/animate_auto.jquery.js
@@ -1,6 +1,6 @@
 /*!
 *
-* jQuery animateAuto Plugin 1.1.2
+* jQuery animateAuto Plugin v1.1.3
 * Based on the original code provided by Darcy Clarke at:
 * http://darcyclarke.me/development/fix-jquerys-animate-to-allow-auto-values/
 *
@@ -22,9 +22,9 @@
 		return this.each(function(i, el){
 			//Create a copy of the element, then measure it's height and width if they were "auto"
 			elem = $(el);
-			clone = elem.clone().css({"height":"auto","width":"auto"}).appendTo(elem.parent());
-			height = clone.css("height");
-			width = clone.css("width");
+			clone = elem.clone().css({height:'auto', width:'auto'}).appendTo(elem.parent());
+			height = clone.height();
+			width = clone.width();
 			clone.remove();
 
 			//Temporarily change the height and width property if the original parameters had them listed as "auto"

--- a/animate_auto.jquery.js
+++ b/animate_auto.jquery.js
@@ -1,12 +1,14 @@
 /*!
- *
- * jQuery Animate Auto Values Plugin v.1.0
- * http://darcyclarke.me/development/fix-jquerys-animate-to-allow-auto-values/
- *
- * Copyright 2011, Darcy Clarke
- * Do what you want license
- * 
- */
+*
+* jQuery animateAuto Plugin v.1.0
+* Based on the original code provided by Darcy Clarke at:
+* http://darcyclarke.me/development/fix-jquerys-animate-to-allow-auto-values/
+*
+* Copyright 2013, Alex Zaslavsky
+* MIT License
+* 
+*/
+
 jQuery.fn.animateAuto = function(prop, speed, callback){
     var elem, height, width;
     return this.each(function(i, el){
@@ -14,12 +16,12 @@ jQuery.fn.animateAuto = function(prop, speed, callback){
         height = elem.css("height"),
         width = elem.css("width"),
         elem.remove();
-        
+
         if(prop === "height")
-            el.animate({"height":height}, speed, callback);
+         el.animate({"height":height}, speed, callback);
         else if(prop === "width")
-            el.animate({"width":width}, speed, callback);  
+          el.animate({"width":width}, speed, callback);  
         else if(prop === "both")
-            el.animate({"width":width,"height":height}, speed, callback);
+          el.animate({"width":width,"height":height}, speed, callback);
     });  
 }

--- a/animate_auto.min.jquery.js
+++ b/animate_auto.min.jquery.js
@@ -1,12 +1,12 @@
 /*!
 *
-* jQuery animateAuto Plugin v1.1.3
+* jQuery animateAuto Plugin v1.1.4
 * Based on the original code provided by Darcy Clarke at:
 * http://darcyclarke.me/development/fix-jquerys-animate-to-allow-auto-values/
 *
-* Copyright 2013, Alex Zaslavsky
+* Copyright 2014, Alex Zaslavsky
 * MIT License
 * 
 */
 
-(function(e){var t=e;var n=e.fn.animate;e.fn.animate=function(){var r=arguments[0];var i=e.speed(arguments[1],arguments[2],arguments[3]);var s,o,u,a,f,l,c;return this.each(function(e,h){s=t(h);o=s.clone().css({height:"auto",width:"auto"}).appendTo(s.parent());u=o.height();a=o.width();o.remove();f={};if(r.height&&r.height==="auto"){f.height=r.height=u}if(r.width&&r.width==="auto"){f.width=r.width=a}l=t.extend(true,{},i);if(l.callback){c=l.callback;l.callback=function(){for(var e in f){s.css(e,"auto")}c.call(s)}}n.call(s,r,i)})}})(jQuery)
+(function(e){var t=e;var n=e.fn.animate;e.fn.animate=function(){var r=arguments[0];var i=e.speed(arguments[1],arguments[2],arguments[3]);return this.each(function(e,s){var o,u,a,f,l,c,h;o=t(s);u=o.clone().css({height:"auto",width:"auto"}).appendTo(o.parent());a=u.height();f=u.width();u.remove();l={};if(r.height&&r.height==="auto"){l.height=r.height=a}if(r.width&&r.width==="auto"){l.width=r.width=f}c=t.extend(true,{},i);if(c.complete){h=c.complete;c.complete=function(){for(var e in l){o.css(e,"auto")}h.call(o)}}n.call(o,r,c)})}})(jQuery)

--- a/animate_auto.min.jquery.js
+++ b/animate_auto.min.jquery.js
@@ -9,4 +9,4 @@
 * 
 */
 
-jQuery.fn.animateAuto=function(e,t,n){var r,i,s;return this.each(function(o,u){u=$(u);r=u.clone().css({height:"auto",width:"auto"}).appendTo(u.parent());i=r.css("height");s=r.css("width");r.remove();var a=function(){if(prop!=="both"){u.css(prop,"auto")}else{u.css({height:"auto",width:"auto"})}if(n){n.call(u)}};if(e.height&&e.height==="auto"){e.height=i}if(e.width&&e.width==="auto"){e.width=s}u.animate(e,t,a)})}
+var animate=jQuery.fn.animate;jQuery.fn.animate=function(){var e=arguments[0];var t=jQuery.speed(arguments[1],arguments[2],arguments[3]);var n,r,i,s;return this.each(function(o,u){n=$(u);r=n.clone().css({height:"auto",width:"auto"}).appendTo(n.parent());i=r.css("height");s=r.css("width");r.remove();var a={};if(e.height&&e.height==="auto"){a.height=e.height=i}if(e.width&&e.width==="auto"){a.width=e.width=s}var f=function(){for(var e in a){n.css(e,"auto")}if(t.callback){t.callback.call(n)}};animate.call(n,e,t)})}

--- a/animate_auto.min.jquery.js
+++ b/animate_auto.min.jquery.js
@@ -1,6 +1,6 @@
 /*!
 *
-* jQuery animateAuto Plugin 1.1.2
+* jQuery animateAuto Plugin v1.1.3
 * Based on the original code provided by Darcy Clarke at:
 * http://darcyclarke.me/development/fix-jquerys-animate-to-allow-auto-values/
 *
@@ -9,4 +9,4 @@
 * 
 */
 
-(function(e){var t=e;var n=e.fn.animate;e.fn.animate=function(){var r=arguments[0];var i=e.speed(arguments[1],arguments[2],arguments[3]);var s,o,u,a,f,l,c;return this.each(function(e,h){s=t(h);o=s.clone().css({height:"auto",width:"auto"}).appendTo(s.parent());u=o.css("height");a=o.css("width");o.remove();f={};if(r.height&&r.height==="auto"){f.height=r.height=u}if(r.width&&r.width==="auto"){f.width=r.width=a}l=t.extend(true,{},i);if(l.callback){c=l.callback;l.callback=function(){for(var e in f){s.css(e,"auto")}c.call(s)}}n.call(s,r,i)})}})(jQuery)
+(function(e){var t=e;var n=e.fn.animate;e.fn.animate=function(){var r=arguments[0];var i=e.speed(arguments[1],arguments[2],arguments[3]);var s,o,u,a,f,l,c;return this.each(function(e,h){s=t(h);o=s.clone().css({height:"auto",width:"auto"}).appendTo(s.parent());u=o.height();a=o.width();o.remove();f={};if(r.height&&r.height==="auto"){f.height=r.height=u}if(r.width&&r.width==="auto"){f.width=r.width=a}l=t.extend(true,{},i);if(l.callback){c=l.callback;l.callback=function(){for(var e in f){s.css(e,"auto")}c.call(s)}}n.call(s,r,i)})}})(jQuery)

--- a/animate_auto.min.jquery.js
+++ b/animate_auto.min.jquery.js
@@ -1,10 +1,12 @@
 /*!
- *
- * jQuery Animate Auto Values Plugin v.1.0
- * http://darcyclarke.me/development/fix-jquerys-animate-to-allow-auto-values/
- *
- * Copyright 2011, Darcy Clarke
- * Do what you want license
- * 
- */
-jQuery.fn.animateAuto=function(a,b,c){var d,e,f;return this.each(function(g,h){h=jQuery(h),d=h.clone().css({height:"auto",width:"auto"}).appendTo("body");e=d.css("height"),f=d.css("width"),d.remove();if(a==="height")h.animate({height:e},b,c);else if(a==="width")h.animate({width:f},b,c);else if(a==="both")h.animate({width:f,height:e},b,c)})}
+*
+* jQuery animateAuto Plugin v.1.0
+* Based on the original code provided by Darcy Clarke at:
+* http://darcyclarke.me/development/fix-jquerys-animate-to-allow-auto-values/
+*
+* Copyright 2013, Alex Zaslavsky
+* MIT License
+* 
+*/
+
+jQuery.fn.animateAuto=function(e,t,n){var r,i,s;return this.each(function(o,u){u=$(u);r=u.clone().css({height:"auto",width:"auto"}).appendTo(u.parent());i=r.css("height");s=r.css("width");r.remove();var a=function(){if(prop!=="both"){u.css(prop,"auto")}else{u.css({height:"auto",width:"auto"})}if(n){n.call(u)}};if(e.height&&e.height==="auto"){e.height=i}if(e.width&&e.width==="auto"){e.width=s}u.animate(e,t,a)})}

--- a/animate_auto.min.jquery.js
+++ b/animate_auto.min.jquery.js
@@ -9,4 +9,4 @@
 * 
 */
 
-var animate=jQuery.fn.animate;jQuery.fn.animate=function(){var e=arguments[0];var t=jQuery.speed(arguments[1],arguments[2],arguments[3]);var n,r,i,s;return this.each(function(o,u){n=$(u);r=n.clone().css({height:"auto",width:"auto"}).appendTo(n.parent());i=r.css("height");s=r.css("width");r.remove();var a={};if(e.height&&e.height==="auto"){a.height=e.height=i}if(e.width&&e.width==="auto"){a.width=e.width=s}var f=function(){for(var e in a){n.css(e,"auto")}if(t.callback){t.callback.call(n)}};animate.call(n,e,t)})}
+(function(e){var t=e;var n=e.fn.animate;e.fn.animate=function(){var r=arguments[0];var i=e.speed(arguments[1],arguments[2],arguments[3]);var s,o,u,a;return this.each(function(e,f){s=t(f);o=s.clone().css({height:"auto",width:"auto"}).appendTo(s.parent());u=o.css("height");a=o.css("width");o.remove();var l={};if(r.height&&r.height==="auto"){l.height=r.height=u}if(r.width&&r.width==="auto"){l.width=r.width=a}var c=function(){for(var e in l){s.css(e,"auto")}if(i.callback){i.callback.call(s)}};n.call(s,r,i)})}})(jQuery)

--- a/animate_auto.min.jquery.js
+++ b/animate_auto.min.jquery.js
@@ -1,6 +1,6 @@
 /*!
 *
-* jQuery animateAuto Plugin v.1.0
+* jQuery animateAuto Plugin 1.1.2
 * Based on the original code provided by Darcy Clarke at:
 * http://darcyclarke.me/development/fix-jquerys-animate-to-allow-auto-values/
 *
@@ -9,4 +9,4 @@
 * 
 */
 
-(function(e){var t=e;var n=e.fn.animate;e.fn.animate=function(){var r=arguments[0];var i=e.speed(arguments[1],arguments[2],arguments[3]);var s,o,u,a;return this.each(function(e,f){s=t(f);o=s.clone().css({height:"auto",width:"auto"}).appendTo(s.parent());u=o.css("height");a=o.css("width");o.remove();var l={};if(r.height&&r.height==="auto"){l.height=r.height=u}if(r.width&&r.width==="auto"){l.width=r.width=a}var c=function(){for(var e in l){s.css(e,"auto")}if(i.callback){i.callback.call(s)}};n.call(s,r,i)})}})(jQuery)
+(function(e){var t=e;var n=e.fn.animate;e.fn.animate=function(){var r=arguments[0];var i=e.speed(arguments[1],arguments[2],arguments[3]);var s,o,u,a,f,l,c;return this.each(function(e,h){s=t(h);o=s.clone().css({height:"auto",width:"auto"}).appendTo(s.parent());u=o.css("height");a=o.css("width");o.remove();f={};if(r.height&&r.height==="auto"){f.height=r.height=u}if(r.width&&r.width==="auto"){f.width=r.width=a}l=t.extend(true,{},i);if(l.callback){c=l.callback;l.callback=function(){for(var e in f){s.css(e,"auto")}c.call(s)}}n.call(s,r,i)})}})(jQuery)

--- a/package
+++ b/package
@@ -4,7 +4,7 @@
   "author": {
     "name": "Alex Zaslavsky"
   },
-  "version": "1.1",
+  "version": "1.1.1",
   "dependencies": {
     "jquery": ">=1.8.0"
   }

--- a/package
+++ b/package
@@ -1,0 +1,11 @@
+{
+  "name": "jQuery-animateAuto",
+  "description": "Allow 'auto' to be a workable value for height and width in jQuery animations",
+  "author": {
+    "name": "Alex Zaslavsky"
+  },
+  "version": "1.0",
+  "dependencies": {
+    "jquery": ">=1.8.0"
+  }
+}

--- a/package
+++ b/package
@@ -4,7 +4,7 @@
   "author": {
     "name": "Alex Zaslavsky"
   },
-  "version": "1.1.3",
+  "version": "1.1.4",
   "dependencies": {
     "jquery": ">=1.8.0"
   }

--- a/package
+++ b/package
@@ -4,7 +4,7 @@
   "author": {
     "name": "Alex Zaslavsky"
   },
-  "version": "1.1.1",
+  "version": "1.1.2",
   "dependencies": {
     "jquery": ">=1.8.0"
   }

--- a/package
+++ b/package
@@ -4,7 +4,7 @@
   "author": {
     "name": "Alex Zaslavsky"
   },
-  "version": "1.0",
+  "version": "1.1",
   "dependencies": {
     "jquery": ">=1.8.0"
   }

--- a/package
+++ b/package
@@ -4,7 +4,7 @@
   "author": {
     "name": "Alex Zaslavsky"
   },
-  "version": "1.1.2",
+  "version": "1.1.3",
   "dependencies": {
     "jquery": ">=1.8.0"
   }


### PR DESCRIPTION
Basically wrapped this into the native "animate" method, which creates more straightforward readability and allows the animation to be paired with other non-dimensional transforms (ex, positioning or background color) in the same rule list.

Also, upon completion, the callback function is now wrapped such that the height/width is reset back to "auto" rather than its calculated pixel value.
